### PR TITLE
Update documentation around pointer-events support in browsers.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -378,7 +378,7 @@ text-transform: uppercase;
 <dt><span class="key">G</span> + <span class="key">J</span></dt>
 <dd>Jump to the next grid. Pressing <span class="key">J</span> while the grid is held also works.</dd>
 </dl>
-<p><em>N.B. A cookie conveniently remembers the state of the grid when you refresh the page. While the grid is in front, you will not be able to interact with the page.</em></p>
+<p><em>N.B. A cookie conveniently remembers the state of the grid when you refresh the page. While the grid is in front, you will not be able to interact with the page except in Chrome v4, Safari v4, Firefox v3.6, or more recent versions.</em></p>
 
 <h2 id="release-notes">Release Notes</h2>
 <dl>


### PR DESCRIPTION
There's a nota bene on the documentation page that doesn't tell the full story of working with the development page while the grid is in the front. This spells the situation out a bit further. At the present there's no signs of `pointer-events: none` support showing up in the two missing browsers as it's not in IE 9 preview 6 nor Opera 11 alpha.
