### PR TITLE
Append optimization in loops

### DIFF
--- a/hashgrid.js
+++ b/hashgrid.js
@@ -110,10 +110,12 @@ var hashgrid = function(set) {
 	if (lineHeight <= 0) return true;
 
 	// Add the remaining grid lines
-	var i, numGridLines = Math.floor(pageHeight / lineHeight);
+	var i, numGridLines = Math.floor(pageHeight / lineHeight),
+      gridLines = ''; 
 	for (i = numGridLines - 1; i >= 1; i--) {
-		overlay.append('<div class="horiz"></div>');
+	  gridLines += '<div class="horiz"></div>';
 	}
+  overlay.append(gridLines);
 
 	// vertical grid
 	overlay.append($('<div class="vert-container"></div>'));
@@ -124,9 +126,11 @@ var hashgrid = function(set) {
 
 	// 30 is an arbitrarily large number...
 	// can't calculate the margin width properly
+  var gridVert = '';
 	for (i = 0; i < 30; i++) {
-		overlayVert.append('<div class="vert">&nbsp;</div>');
+    gridVert += '<div class="vert">&nbsp;</div>';
 	}
+  overlayVert.append(gridVert);
 
 	overlayVert.children()
 		.height(pageHeight)


### PR DESCRIPTION
I noticed that there was a slow down when testing a rather long page in IE7, while I'm not 100% sure that hashgrid was the culprit, I did find it odd that you would call jQuery's append() inside of a for loop. This amounts to calling appendChild as many times as you have grid lines, on the hashgrid website its about 180 times. 

I've pulled the append() to outside of the for loop so it's only called once rather than (pageHeight / lineHeight) times ( which could get quite big ).

This may also fix the Firefox unresponsive script issue that has been reported. Though I have not tested this. 

Thanks,
Andrew
