### PR TITLE
Set valid cookies

### DIFF
--- a/hashgrid.js
+++ b/hashgrid.js
@@ -185,7 +185,7 @@ var hashgrid = function(set) {
 	// Check for saved state
 	overlayCookie = readCookie(options.cookiePrefix + options.id);
 	if (typeof overlayCookie == 'string') {
-		state = overlayCookie.split(',');
+		state = overlayCookie.split('-');
 		state[2] = Number(state[2]);
 		if ((typeof state[2] == 'number') && !isNaN(state[2])) {
 			classNumber = state[2].toFixed(0);
@@ -242,7 +242,7 @@ var hashgrid = function(set) {
 	}
 
 	function saveState() {
-		createCookie(options.cookiePrefix + options.id, (sticky ? '1' : '0') + ',' + overlayZState + ',' + classNumber, 1);
+		createCookie(options.cookiePrefix + options.id, (sticky ? '1' : '0') + '-' + overlayZState + '-' + classNumber, 1);
 	}
 
 	function showOverlay() {


### PR DESCRIPTION
Some user agents choke or spew warnings when you have a cookie with a comma in the value. They may work, but I believe it's better to follow the spec and not cause potential problems.

According to RFC 6265 the cookie value should only contain "US-ASCII characters excluding CTLs, whitespace DQUOTE, comma, semicolon, and backslash" [1]

RFC 6265 is the most recent RFC regarding cookies, but the restriction on the use of commas goes back to the original netscape cookie spec. [2]

I've simply changed the commas to dashes, any other character will do.

[1] http://tools.ietf.org/html/rfc6265#section-4.1.1
[2] http://curl.haxx.se/rfc/cookie%5Fspec.html
