### PR TITLE
Avoid errors with jQuery used in noConflict mode

### DIFF
--- a/hashgrid.js
+++ b/hashgrid.js
@@ -216,7 +216,7 @@ var hashgrid = function(set) {
 	 */
 
 	function getModifier(e) {
-		if (options.modifierKey == null) return true; // Bypass by default
+		if (options.modifierKey === null) return true; // Bypass by default
 		var m = true;
 		switch(options.modifierKey) {
 			case 'ctrl':
@@ -395,7 +395,7 @@ var hashgrid = function(set) {
 				c = c.substring(1, c.length);
 			}
 
-			if (c.indexOf(nameEQ) == 0) {
+			if (c.indexOf(nameEQ) === 0) {
 				return c.substring(nameEQ.length, c.length);
 			}
 		}


### PR DESCRIPTION
I found out that hashgrid would not work after [jQuery.noConflict()](http://api.jquery.com/jQuery.noConflict/) since it's using `window.$` instead of `window.jQuery`. 

For example, Wordpress does this this after it's done using jQuery for its own purposes.

I fixed this by redefining `$` inside `hashgrid()` and using `jQuery()` to initialize the script.
